### PR TITLE
Add LangChain-based AI pipeline

### DIFF
--- a/agents/architect.py
+++ b/agents/architect.py
@@ -1,0 +1,23 @@
+from langchain.llms import Ollama
+from langchain.prompts import PromptTemplate
+from langchain.chains import LLMChain
+
+
+class Architect:
+    """Agent that designs high-level architecture."""
+
+    def __init__(self, model: str = "mistral"):
+        llm = Ollama(model=model)
+        prompt = PromptTemplate(
+            input_variables=["request", "context"],
+            template=(
+                "You are a software architect. Using the following context:\n"
+                "{context}\n"
+                "Design an architecture for the feature request: {request}"
+            ),
+        )
+        self.chain = LLMChain(llm=llm, prompt=prompt)
+
+    def run(self, request: str, context: str) -> str:
+        """Generate an architecture plan."""
+        return self.chain.run(request=request, context=context)

--- a/agents/engineer.py
+++ b/agents/engineer.py
@@ -1,0 +1,22 @@
+from langchain.llms import Ollama
+from langchain.prompts import PromptTemplate
+from langchain.chains import LLMChain
+
+
+class Engineer:
+    """Agent that writes code implementations."""
+
+    def __init__(self, model: str = "mistral"):
+        llm = Ollama(model=model)
+        prompt = PromptTemplate(
+            input_variables=["request", "context"],
+            template=(
+                "You are a senior software engineer. Using the context:\n"
+                "{context}\n"
+                "Implement the feature request: {request}. Provide code snippets only."
+            ),
+        )
+        self.chain = LLMChain(llm=llm, prompt=prompt)
+
+    def run(self, request: str, context: str) -> str:
+        return self.chain.run(request=request, context=context)

--- a/agents/reviewer.py
+++ b/agents/reviewer.py
@@ -1,0 +1,23 @@
+from langchain.llms import Ollama
+from langchain.prompts import PromptTemplate
+from langchain.chains import LLMChain
+
+
+class Reviewer:
+    """Agent that reviews generated code."""
+
+    def __init__(self, model: str = "mistral"):
+        llm = Ollama(model=model)
+        prompt = PromptTemplate(
+            input_variables=["code", "context"],
+            template=(
+                "You are a code reviewer. Review the following code:\n"
+                "{code}\n"
+                "Using this context:\n{context}\n"
+                "Provide improvement suggestions."
+            ),
+        )
+        self.chain = LLMChain(llm=llm, prompt=prompt)
+
+    def run(self, code: str, context: str) -> str:
+        return self.chain.run(code=code, context=context)

--- a/agents/tester.py
+++ b/agents/tester.py
@@ -1,0 +1,23 @@
+from langchain.llms import Ollama
+from langchain.prompts import PromptTemplate
+from langchain.chains import LLMChain
+
+
+class Tester:
+    """Agent that generates test cases."""
+
+    def __init__(self, model: str = "mistral"):
+        llm = Ollama(model=model)
+        prompt = PromptTemplate(
+            input_variables=["code", "context"],
+            template=(
+                "You are a QA engineer. Write test cases for the following code:\n"
+                "{code}\n"
+                "Use this context:\n{context}\n"
+                "Return the test plan or test code."
+            ),
+        )
+        self.chain = LLMChain(llm=llm, prompt=prompt)
+
+    def run(self, code: str, context: str) -> str:
+        return self.chain.run(code=code, context=context)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,20 @@
+from orchestrator import Orchestrator
+from vectorstore import CodeVectorStore
+
+
+def main() -> None:
+    # Index the current codebase
+    store = CodeVectorStore(path=".")
+    store.index()
+
+    feature_request = input("Enter feature request: ")
+
+    orchestrator = Orchestrator(store)
+    outputs = orchestrator.run(feature_request)
+
+    for agent, result in outputs.items():
+        print(f"\n=== {agent.capitalize()} Output ===\n{result}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,38 @@
+from typing import Dict
+
+from langchain.llms import Ollama
+
+from agents.architect import Architect
+from agents.engineer import Engineer
+from agents.reviewer import Reviewer
+from agents.tester import Tester
+from vectorstore import CodeVectorStore
+
+
+class Orchestrator:
+    """Coordinates the agent pipeline."""
+
+    def __init__(self, store: CodeVectorStore, model: str = "mistral"):
+        self.store = store
+        self.llm = Ollama(model=model)
+        self.architect = Architect(model=model)
+        self.engineer = Engineer(model=model)
+        self.reviewer = Reviewer(model=model)
+        self.tester = Tester(model=model)
+
+    def run(self, request: str) -> Dict[str, str]:
+        docs = self.store.query(request)
+        context = "\n".join(d.page_content for d in docs)
+
+        arch_out = self.architect.run(request, context)
+        eng_context = context + "\n" + arch_out
+        eng_out = self.engineer.run(request, eng_context)
+        rev_out = self.reviewer.run(eng_out, context)
+        test_out = self.tester.run(eng_out, context)
+
+        return {
+            "architect": arch_out,
+            "engineer": eng_out,
+            "reviewer": rev_out,
+            "tester": test_out,
+        }

--- a/vectorstore.py
+++ b/vectorstore.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+from typing import List
+
+from langchain.docstore.document import Document
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.embeddings import OllamaEmbeddings
+from langchain.vectorstores import FAISS
+
+
+class CodeVectorStore:
+    """Utility for indexing and querying the codebase."""
+
+    def __init__(self, path: str, model: str = "mistral"):
+        self.path = path
+        self.embedding = OllamaEmbeddings(model=model)
+        self.store: FAISS | None = None
+
+    def _load_documents(self) -> List[Document]:
+        docs: List[Document] = []
+        for root, _, files in os.walk(self.path):
+            for file in files:
+                if file.endswith((".py", ".java", ".md", ".txt")):
+                    fpath = os.path.join(root, file)
+                    try:
+                        with open(fpath, "r", encoding="utf-8") as f:
+                            text = f.read()
+                    except Exception:
+                        continue
+                    docs.append(Document(page_content=text, metadata={"source": fpath}))
+        splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=100)
+        return splitter.split_documents(docs)
+
+    def index(self) -> None:
+        """Load documents from the path and build the vector store."""
+        docs = self._load_documents()
+        self.store = FAISS.from_documents(docs, self.embedding)
+
+    def query(self, text: str, k: int = 4) -> List[Document]:
+        if not self.store:
+            raise ValueError("Vector store not indexed")
+        return self.store.similarity_search(text, k=k)


### PR DESCRIPTION
## Summary
- add FAISS vector DB utility with Ollama embeddings
- implement Architect, Engineer, Reviewer, and Tester agents
- create orchestrator for sequential agent execution
- provide main.py entry point to run the pipeline

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6884076483e4832b94bc08347556687d